### PR TITLE
no unnecessary triple for pythontexless

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,19 @@ A Moodle quiz generator using LaTeX and the `moodle.sty` package with jinja2 tem
 `genquiz` is a wrapper script that performs mail-merge like functionality to generate a Moodle quiz XML file for bulk upload. It uses a template latex file based on the [`moodle.sty`](https://framagit.org/mattgk/moodle) package, and populates placeholder variables with entries from a prepared csv file to generate many variants of the template question. It can include the answers, precision, and feedback; all as described in the documentaion for the `moodle.sty` package.
 
 ## Useage
-Example command to follow...
+When located in a different directory, that is added to PYTHONPATH:
+
+```python
+python -m genquiz [template].tex [database].csv  -s
+```
+
+otherwise, when in the same directory: 
+
+```python
+python genquiz.py [template].tex [database].csv  -s
+```
+
+-s is an indicator to say that there is no pythontex variables the template.
 
 ## Warning
 `genquiz` is functional, but the code needs to be cleaned up and documentation produced.

--- a/genquiz.py
+++ b/genquiz.py
@@ -89,7 +89,7 @@ def generic(csvfile):
     return df, keys
 
 
-def gen_files(values, keys, template, delete_temps):
+def gen_files(values, keys, template, delete_temps, pythontex):
     """
     Drives the rendering and compilation process for each row, and
     cleans up the files afterwards.
@@ -119,7 +119,7 @@ def gen_files(values, keys, template, delete_temps):
     render_file(values, keys, template, tmpfile)
 
     try:
-        compile_files(values, tmpfile)
+        compile_files(values, tmpfile, pythontex)
 
     finally:
         if delete_temps:
@@ -135,7 +135,7 @@ def gen_files(values, keys, template, delete_temps):
                 shutil.rmtree(path, onerror=remove_readonly)
 
 
-def compile_files(values, tmpfile):
+def compile_files(values, tmpfile, pythontex=True):
     """
     Generates the Questions and Answers documents for a student
 
@@ -168,8 +168,9 @@ def compile_files(values, tmpfile):
     # This step generates the variables & solutions
     # SHould update to use the Popen function, and evaluate the returned args
     subprocess.call(cmd_pdflatex, shell=True)
-    subprocess.call(cmd_pythontex, shell=True)
-    subprocess.call(cmd_pdflatex, shell=True)
+    if pythontex:
+        subprocess.call(cmd_pythontex, shell=True)
+        subprocess.call(cmd_pdflatex, shell=True)
 
     # file_mask = params.file_mask
     # folder_mask = params.folder_mask
@@ -276,7 +277,8 @@ def main(args):
 
     # Apply function to each row of df
     df.apply(
-        gen_files, axis=1, keys=keys, template=template, delete_temps=args.delete_temps
+        gen_files, axis=1, keys=keys, template=template, 
+        delete_temps=args.delete_temps, pythontex=args.simple
     )
 
     # Now merge the generated XML files
@@ -312,6 +314,15 @@ if __name__ == "__main__":
         "-d",
         "--delete_temps",
         help="Whether or not to delete temporary files",
+        required=False,
+        default=True,
+        action="store_false",
+    )
+
+    parser.add_argument(
+        "-s",
+        "--simple",
+        help="Whether or not template file requires pythontex",
         required=False,
         default=True,
         action="store_false",


### PR DESCRIPTION
Changes to script to speed up pythontex-less document, as well as on documentation for usage, particularly when module is in different directory on PYTHONPATH vs the same directory.